### PR TITLE
adapting callsign format to solve issue #2

### DIFF
--- a/form_site.cgi
+++ b/form_site.cgi
@@ -398,7 +398,7 @@ sub checkValues {
      my $test = 0;
   }    
   else {
-    unless ($callsign=~/^[a-z0-9]{3,6}-*\d*$/ && $callsign=~/[0-9][a-z]-*\d*/) {
+    unless ($callsign=~/^([a-z]{2}|[a-z][2-9]|[2-9][a-z])[0-9][a-z]{1,4}-*\d*$/ && $callsign=~/[0-9][a-z]-*\d*/) {
       $inputStatus= "Callsign seems to have incorrect format";
     }
     if ($no_check==3) {

--- a/rest.cgi
+++ b/rest.cgi
@@ -19,7 +19,7 @@ if ($query->param('m') eq "querycall") {
   print("Content-Type: application/json\nExpires: 0\n\n");
   &json_obj();
   my $callsign=lc($query->param('call'));
-  if ($callsign =~ /^[a-z]{1,2}[0-9][a-z]{1,3}(-\d{1,2})?$/ || $callsign =~ /^nocall_\d+$/) {
+  if ($callsign =~ /^([a-z]{2}|[a-z][2-9]|[2-9][a-z])[0-9][a-z]{1,4}(-\d{1,2})?$/ || $callsign =~ /^nocall_\d+$/) {
     my $search = $db->quote($callsign);
     my $sth= $db->prepare(qq(
       select callsign,latitude,longitude,elevation from hamnet_site


### PR DESCRIPTION
adapting the regex used to validate callsigns.

Regex allows for prefixes of 2 letters, or 1 letter and 1 number (2-9 as defined by ITU) and suffixes up to 4 characters.

This should solve issue #2 